### PR TITLE
Always clean plunger tmp files

### DIFF
--- a/lib/controllers/filePackages.js
+++ b/lib/controllers/filePackages.js
@@ -1,6 +1,7 @@
 const Plunger = require('../helpers/plunger');
 const { strLeftBack } = require('underscore.string');
 const { find, includes } = require('lodash');
+const onFinished = require('on-finished');
 
 
 exports.loadLayer = function (req, res, next) {
@@ -54,6 +55,11 @@ exports.prepateFilePackageDownload = function (req, res, next) {
     }
 
     req.plunger = new Plunger(req.remoteResource.location, { abort: 'never' });
+
+    onFinished(res, () => {
+      req.plunger.cleanup()
+        .catch(() => console.error('Unable to clean plunger temp directory'));
+    });
 
     req.plunger.inspect()
         .then(() => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "morgan": "^1.5.1",
     "multistream": "^2.0.2",
     "ogr2ogr": "jdesboeufs/ogr2ogr",
+    "on-finished": "^2.3.0",
     "passport": "^0.2.1",
     "passport-oauth2": "^1.1.2",
     "plunger": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,7 +1801,7 @@ ogr2ogr@jdesboeufs/ogr2ogr:
     findit "^2.0.0"
     rimraf "^2.2.8"
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:


### PR DESCRIPTION
When called for user download, plunger never clean its temp files.
Now it's done!